### PR TITLE
fix the link for sample projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,8 +243,8 @@ return  app.stream( inputs );
 [javadocs]: https://bsorrentino.github.io/langgraph4j/apidocs/index.html
 [springai-agentexecutor]: samples/springai-agentexecutor
 [agent-executor]: agent-executor/
-[adaptive-rag]: samples/image-to-diagram/
-[image-to-diagram]: samples/adaptive-rag
+[adaptive-rag]: samples/adaptive-rag
+[image-to-diagram]: samples/image-to-diagram/
 [howto-presistence]: how-tos/persistence.ipynb
 [howto-timetravel]: how-tos/time-travel.ipynb
 


### PR DESCRIPTION
The link for sample project `Image To PlantUML Diagram` and `Adaptive RAG` are wrong. Fixed by swapping the links

<img width="397" alt="image" src="https://github.com/user-attachments/assets/02308ab2-c34b-4b78-9949-49ce6a0003d3" />
