### PR TITLE
Spring AI to 1.0.0-M8, add maven threads config

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,1 @@
+--threads=1C

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <langchain4j.version>1.0.0-rc1</langchain4j.version>
     <langchain4j.beta>1.0.0-beta4</langchain4j.beta>
-    <spring-ai.version>1.0.0-M7</spring-ai.version>
+    <spring-ai.version>1.0.0-M8</spring-ai.version>
   </properties>
 
   <distributionManagement>

--- a/spring-ai-agent/pom.xml
+++ b/spring-ai-agent/pom.xml
@@ -27,7 +27,7 @@
 
 	<properties>
 		<java.version>17</java.version>
-        <spring-ai.version>1.0.0-M7</spring-ai.version>
+        <spring-ai.version>1.0.0-M8</spring-ai.version>
 	</properties>
 
 	<dependencies>

--- a/spring-ai-agent/src/main/java/org/bsc/langgraph4j/spring/ai/agentexecutor/AgentExecutor.java
+++ b/spring-ai-agent/src/main/java/org/bsc/langgraph4j/spring/ai/agentexecutor/AgentExecutor.java
@@ -13,6 +13,7 @@ import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.tool.ToolCallback;
+import org.springframework.ai.tool.ToolCallbackProvider;
 import org.springframework.ai.tool.ToolCallbacks;
 
 import java.util.*;
@@ -73,11 +74,20 @@ public interface AgentExecutor {
             return this;
         }
 
+        public Builder tools(ToolCallbackProvider toolCallbackProvider) {
+            Objects.requireNonNull(toolCallbackProvider, "toolCallbackProvider cannot be null!");
+            var toolCallbacks = toolCallbackProvider.getToolCallbacks();
+            if (toolCallbacks.length == 0) {
+                throw new IllegalArgumentException("toolCallbackProvider.getToolCallbacks() cannot be empty!");
+            }
+            this.tools.addAll(List.of(toolCallbacks));
+            return this;
+        }
+
         public Builder toolsFromObject(Object objectWithTools) {
             var tools = ToolCallbacks.from( Objects.requireNonNull(objectWithTools, "objectWithTools cannot be null" ));
             this.tools.addAll(List.of(tools));
             return this;
-
         }
 
         @Deprecated(forRemoval = true)

--- a/spring-ai/pom.xml
+++ b/spring-ai/pom.xml
@@ -18,7 +18,7 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <spring-ai.version>1.0.0-M7</spring-ai.version>
+        <spring-ai.version>1.0.0-M8</spring-ai.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
Changelist:
1. Spring AI to 1.0.0-M8（[tag v1.0.0-M8](https://github.com/spring-projects/spring-ai/releases/tag/v1.0.0-M8)、[docs 1.0.0-M8](https://docs.spring.io/spring-ai/reference/upgrade-notes.html#upgrading-to-1-0-0-m8)）
2. add Maven threads (--threads=1C) configuration to improve build speed
3. support ToolCallbackProvider for springai.AgentExecutor.Builder

[x] all tests is passed
[x] mvn build/package is successful