### PR TITLE
feat(langgraph4j-mysql-saver): add MySQL saver module and corresponding tests

### DIFF
--- a/langgraph4j-mysql-saver/README.md
+++ b/langgraph4j-mysql-saver/README.md
@@ -1,0 +1,186 @@
+# LangGraph4j MySQL Saver
+
+MySQL persistence implementation for LangGraph4j workflow state management.
+
+## Overview
+
+MysqlSaver extends `MemorySaver` to provide persistent, reliable storage of workflow state in a MySQL database. It uses two tables to manage thread state and checkpoints.
+
+## Database Schema
+
+### LANGRAPH4J_THREAD Table
+```sql
+CREATE TABLE LANGRAPH4J_THREAD (
+    thread_id VARCHAR(36) PRIMARY KEY,
+    thread_name VARCHAR(255),
+    is_released BOOLEAN DEFAULT FALSE NOT NULL
+)
+
+CREATE UNIQUE INDEX IDX_LANGRAPH4J_THREAD_NAME_RELEASED
+    ON LANGRAPH4J_THREAD(thread_name, is_released)
+```
+
+### LANGRAPH4J_CHECKPOINT Table
+```sql
+CREATE TABLE LANGRAPH4J_CHECKPOINT (
+    checkpoint_id VARCHAR(36) PRIMARY KEY,
+    thread_id VARCHAR(36) NOT NULL,
+    node_id VARCHAR(255),
+    next_node_id VARCHAR(255),
+    state_data JSON NOT NULL,
+    saved_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT LANGRAPH4J_FK_THREAD
+        FOREIGN KEY(thread_id)
+        REFERENCES LANGRAPH4J_THREAD(thread_id)
+        ON DELETE CASCADE
+)
+```
+
+## Requirements
+
+- MySQL 8.0 or higher (for JSON column type support)
+- Java 17+
+- MySQL Connector/J 9.2.0+
+
+**Note**: Compatible with all MySQL 8.0.x versions. The implementation uses standard MySQL syntax without relying on version-specific features (e.g., does not require MySQL 8.0.29+ for `CREATE INDEX IF NOT EXISTS`).
+
+## Usage
+
+### Basic Setup
+
+```java
+import com.mysql.cj.jdbc.MysqlDataSource;
+import org.bsc.langgraph4j.checkpoint.MysqlSaver;
+import org.bsc.langgraph4j.checkpoint.CreateOption;
+
+// Create datasource
+MysqlDataSource dataSource = new MysqlDataSource();
+dataSource.setURL("jdbc:mysql://localhost:3306/mydb");
+dataSource.setUser("username");
+dataSource.setPassword("password");
+
+// Create MysqlSaver with auto-creation of tables
+var saver = MysqlSaver.builder()
+    .dataSource(dataSource)
+    .createOption(CreateOption.CREATE_IF_NOT_EXISTS)
+    .build();
+```
+
+### Integration with StateGraph
+
+```java
+import org.bsc.langgraph4j.CompileConfig;
+import org.bsc.langgraph4j.StateGraph;
+
+var graph = new StateGraph<>(AgentState::new)
+    .addNode("agent_1", node_async(agent_1))
+    .addEdge(START, "agent_1")
+    .addEdge("agent_1", END);
+
+var compileConfig = CompileConfig.builder()
+    .checkpointSaver(saver)
+    .releaseThread(false)  // Keep thread active for state history
+    .build();
+
+var workflow = graph.compile(compileConfig);
+```
+
+## CreateOption Values
+
+- **`CREATE_NONE`**: No attempt is made to create schema objects. Use this when tables already exist.
+- **`CREATE_IF_NOT_EXISTS`** (default): Reuses existing schema or creates if missing. Safe to use repeatedly - gracefully handles existing indexes by catching and ignoring duplicate key errors (MySQL error code 1061).
+- **`CREATE_OR_REPLACE`**: Drops and recreates schema objects. **Use with caution** - all existing data will be lost!
+
+### Schema Creation Behavior
+
+The implementation handles schema creation intelligently:
+
+1. **Tables**: Uses `CREATE TABLE IF NOT EXISTS` for safe creation
+2. **Indexes**: Creates indexes with standard syntax, catching and ignoring "Duplicate key name" errors if the index already exists
+3. **Drop Order**: When dropping, tables are dropped in dependency order (CHECKPOINT → THREAD). Indexes are automatically dropped with their tables in MySQL.
+
+## JSON Serialization
+
+MysqlSaver uses Jackson (`com.fasterxml.jackson.databind.ObjectMapper`) for JSON serialization/deserialization. State data is stored as JSON strings in the `state_data` column.
+
+## Key Differences from OracleSaver
+
+| Feature | OracleSaver | MysqlSaver |
+|---------|-------------|------------|
+| **UPSERT Syntax** | `MERGE INTO ... USING ... FROM DUAL` | `INSERT ... ON DUPLICATE KEY UPDATE` |
+| **Data Types** | `VARCHAR2`, `TIMESTAMP WITH TIME ZONE` | `VARCHAR`, `TIMESTAMP` |
+| **JSON Handling** | Oracle OSON (binary JSON) | Jackson ObjectMapper (JSON strings) |
+| **JSON Column** | `JSON` with `OracleType.JSON` | `JSON` with String serialization |
+| **Index Creation** | `IF NOT EXISTS` clause supported | Error handling for duplicate indexes |
+| **Performance Opts** | `defineColumnType`, LOB prefetch | Standard JDBC (no special optimizations) |
+| **Drop Syntax** | `CASCADE CONSTRAINTS` | Standard `DROP TABLE IF EXISTS` |
+
+### MySQL-Specific Implementation Details
+
+1. **UPSERT Thread**: Uses unique index on `(thread_name, is_released)` to prevent duplicate unreleased threads
+   ```sql
+   INSERT INTO LANGRAPH4J_THREAD (thread_id, thread_name, is_released)
+   VALUES (?, ?, FALSE)
+   ON DUPLICATE KEY UPDATE thread_id = thread_id
+   ```
+
+2. **Index Management**: Handles duplicate index errors gracefully (error code 1061) for idempotent initialization
+
+3. **JSON Storage**: State data is serialized to JSON string format, compatible with MySQL's native JSON column type for efficient querying
+
+## Testing
+
+Tests use Testcontainers to spin up a MySQL 8.0 container for integration testing:
+
+```java
+@Test
+public void testCheckpointWithNotReleasedThread() throws Exception {
+    var saver = MysqlSaver.builder()
+        .createOption(CreateOption.CREATE_OR_REPLACE)
+        .dataSource(DATA_SOURCE)
+        .build();
+    
+    // Test checkpoint persistence and state updates
+    // ...
+}
+```
+
+## Dependencies
+
+```xml
+<dependency>
+    <groupId>com.mysql</groupId>
+    <artifactId>mysql-connector-j</artifactId>
+    <version>9.2.0</version>
+</dependency>
+<dependency>
+    <groupId>com.fasterxml.jackson.core</groupId>
+    <artifactId>jackson-databind</artifactId>
+    <version>2.18.2</version>
+</dependency>
+```
+
+## Troubleshooting
+
+### "Duplicate key name" Error
+This error is handled automatically when using `CREATE_IF_NOT_EXISTS` option. The implementation catches MySQL error code 1061 and ignores it. If you encounter this error, ensure you're using `CREATE_IF_NOT_EXISTS` or `CREATE_OR_REPLACE`.
+
+### JSON Column Type Not Supported
+Ensure you're using MySQL 8.0 or higher. MySQL 5.7 JSON support is limited. For MySQL 5.7, consider changing the `state_data` column type to `TEXT` or `LONGTEXT`.
+
+### Connection Issues
+Verify your MySQL connection URL format:
+```java
+dataSource.setURL("jdbc:mysql://localhost:3306/mydb");
+```
+
+For MySQL 8.0+, you may need to specify SSL settings:
+```java
+dataSource.setURL("jdbc:mysql://localhost:3306/mydb?useSSL=false&allowPublicKeyRetrieval=true");
+```
+
+## License
+
+Same as LangGraph4j project.
+

--- a/langgraph4j-mysql-saver/pom.xml
+++ b/langgraph4j-mysql-saver/pom.xml
@@ -1,0 +1,103 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.bsc.langgraph4j</groupId>
+        <artifactId>langgraph4j-parent</artifactId>
+        <version>1.7.0</version>
+    </parent>
+
+    <artifactId>langgraph4j-mysql-saver</artifactId>
+    <packaging>jar</packaging>
+
+    <description>Mysql Saver for LangGraph4j</description>
+    <name>langgraph4j::mysql-saver</name>
+    <url>https://github.com/langgraph4j/langgraph4j</url>
+
+    <scm>
+        <connection>scm:git: https://github.com/langgraph4j/langgraph4j.git</connection>
+        <developerConnection>scm:git: https://github.com/langgraph4j/langgraph4j.git</developerConnection>
+        <url>https://github.com/langgraph4j/langgraph4j</url>
+        <tag>HEAD</tag>
+    </scm>
+
+    <properties>
+        <testcontainers.version>1.21.3</testcontainers.version>
+        <mysql.version>9.2.0</mysql.version>
+        <jackson.version>2.18.2</jackson.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>testcontainers-bom</artifactId>
+                <version>${testcontainers.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.parent.groupId}</groupId>
+            <artifactId>langgraph4j-core</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
+            <version>${mysql.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-launcher</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>mysql</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>**/*ITest.java</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/langgraph4j-mysql-saver/src/main/java/org/bsc/langgraph4j/checkpoint/CreateOption.java
+++ b/langgraph4j-mysql-saver/src/main/java/org/bsc/langgraph4j/checkpoint/CreateOption.java
@@ -1,0 +1,18 @@
+package org.bsc.langgraph4j.checkpoint;
+
+/**
+ * Options which configure the creation of database schema objects, such as
+ * tables and indexes.
+ */
+public enum CreateOption {
+
+    /** No attempt is made to create the schema object. */
+    CREATE_NONE,
+
+    /** An existing schema object is reused, otherwise it is created. */
+    CREATE_IF_NOT_EXISTS,
+
+    /** An existing schema object is dropped and replaced with a new one. */
+    CREATE_OR_REPLACE
+}
+

--- a/langgraph4j-mysql-saver/src/main/java/org/bsc/langgraph4j/checkpoint/MysqlSaver.java
+++ b/langgraph4j-mysql-saver/src/main/java/org/bsc/langgraph4j/checkpoint/MysqlSaver.java
@@ -1,0 +1,366 @@
+package org.bsc.langgraph4j.checkpoint;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.bsc.langgraph4j.RunnableConfig;
+
+import javax.sql.DataSource;
+import java.sql.*;
+import java.util.*;
+
+/**
+ * <p>
+ * MysqlSaver is an extension of MemorySaver that enables persistent,
+ * reliable storage of workflow state in a MySQL database.
+ * </p>
+ * <p>
+ * Two tables are used to store the workflow state:
+ * 
+ * <pre>
+ *     CREATE TABLE LANGRAPH4J_THREAD (
+ *          thread_id VARCHAR(36) PRIMARY KEY,
+ *          thread_name VARCHAR(255),
+ *          is_released BOOLEAN DEFAULT FALSE NOT NULL
+ *     )
+ *     CREATE UNIQUE INDEX IDX_LANGRAPH4J_THREAD_NAME_RELEASED
+ *          ON LANGRAPH4J_THREAD(thread_name, is_released)
+ *
+ *     CREATE TABLE LANGRAPH4J_CHECKPOINT (
+ *          checkpoint_id VARCHAR(36) PRIMARY KEY,
+ *          thread_id VARCHAR(36) NOT NULL,
+ *          node_id VARCHAR(255),
+ *          next_node_id VARCHAR(255),
+ *          state_data JSON NOT NULL,
+ *          saved_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+ *
+ *          CONSTRAINT LANGRAPH4J_FK_THREAD
+ *              FOREIGN KEY(thread_id)
+ *              REFERENCES LANGRAPH4J_THREAD(thread_id)
+ *              ON DELETE CASCADE
+ *     )
+ * </pre>
+ * </p>
+ * <p>
+ * A builder can be used to create an instance of MysqlSaver. The builder
+ * allows to configure the following options:
+ * - DataSource: indicates which data source should be used to connect
+ * to the database
+ * - CreateOption : indicates whether the tables should be created or
+ * existing tables should be used.
+ * </p>
+ * <p>
+ * Ex:
+ * 
+ * <pre>
+ * var saver = MysqlSaver.builder()
+ *         .createOption(CreateOption.CREATE_OR_REPLACE)
+ *         .dataSource(DATA_SOURCE)
+ *         .build();
+ * </pre>
+ * </p>
+ */
+public class MysqlSaver extends MemorySaver {
+
+    // DDL statements
+    private static final String CREATE_THREAD_TABLE = """
+            CREATE TABLE IF NOT EXISTS LANGRAPH4J_THREAD (
+               thread_id VARCHAR(36) PRIMARY KEY,
+               thread_name VARCHAR(255),
+               is_released BOOLEAN DEFAULT FALSE NOT NULL
+            )""";
+
+    private static final String INDEX_THREAD_TABLE = """
+            CREATE UNIQUE INDEX IDX_LANGRAPH4J_THREAD_NAME_RELEASED
+              ON LANGRAPH4J_THREAD(thread_name, is_released)
+            """;
+
+    private static final String CREATE_CHECKPOINT_TABLE = """
+            CREATE TABLE IF NOT EXISTS LANGRAPH4J_CHECKPOINT (
+               checkpoint_id VARCHAR(36) PRIMARY KEY,
+               thread_id VARCHAR(36) NOT NULL,
+               node_id VARCHAR(255),
+               next_node_id VARCHAR(255),
+               state_data JSON NOT NULL,
+               saved_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+
+               CONSTRAINT LANGRAPH4J_FK_THREAD
+                   FOREIGN KEY(thread_id)
+                   REFERENCES LANGRAPH4J_THREAD(thread_id)
+                   ON DELETE CASCADE
+            )""";
+    
+    private static final String DROP_CHECKPOINT_TABLE = "DROP TABLE IF EXISTS LANGRAPH4J_CHECKPOINT";
+    private static final String DROP_THREAD_TABLE = "DROP TABLE IF EXISTS LANGRAPH4J_THREAD";
+
+    // DML statements
+    private static final String UPSERT_THREAD = """
+            INSERT INTO LANGRAPH4J_THREAD (thread_id, thread_name, is_released)
+            VALUES (?, ?, FALSE)
+            ON DUPLICATE KEY UPDATE thread_id = thread_id
+            """;
+
+    private static final String INSERT_CHECKPOINT = """
+            INSERT INTO LANGRAPH4J_CHECKPOINT(checkpoint_id, thread_id, node_id, next_node_id, state_data)
+            SELECT ?, thread_id, ?, ?, ?
+            FROM LANGRAPH4J_THREAD
+            WHERE thread_name = ? AND is_released = FALSE
+            """;
+
+    private static final String UPDATE_CHECKPOINT = """
+            UPDATE LANGRAPH4J_CHECKPOINT
+            SET
+              checkpoint_id = ?,
+              node_id = ?,
+              next_node_id = ?,
+              state_data = ?
+            WHERE checkpoint_id = ?
+            """;
+
+    private static final String SELECT_CHECKPOINTS = """
+            SELECT
+              c.checkpoint_id,
+              c.node_id,
+              c.next_node_id,
+              c.state_data
+            FROM LANGRAPH4J_CHECKPOINT c
+              INNER JOIN LANGRAPH4J_THREAD t ON c.thread_id = t.thread_id
+            WHERE t.thread_name = ? AND t.is_released != TRUE
+            ORDER BY c.saved_at DESC
+            """;
+
+    private static final String DELETE_CHECKPOINTS = """
+                DELETE FROM LANGRAPH4J_CHECKPOINT WHERE checkpoint_id = ?
+            """;
+
+    private static final String RELEASE_THREAD = """
+            UPDATE LANGRAPH4J_THREAD SET is_released = TRUE WHERE thread_name = ? AND is_released = FALSE
+            """;
+
+    // Configuration
+    private final DataSource dataSource;
+    private final CreateOption createOption;
+    private final ObjectMapper objectMapper;
+
+    /**
+     * Private constructor used by the builder to create a new instance of
+     * MysqlSaver.
+     * 
+     * @param dataSource   the data source
+     * @param createOption the create options
+     */
+    private MysqlSaver(DataSource dataSource, CreateOption createOption) {
+        this.dataSource = dataSource;
+        this.createOption = createOption;
+        this.objectMapper = new ObjectMapper();
+        initTables();
+    }
+
+    /**
+     * Creates an instance of a builder that allows to configure and create a new
+     * instance of MysqlSaver.
+     *
+     * @return a new instance of the builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * If the list of checkpoints is empty, loads the checkpoints from the database.
+     *
+     * @param config      the configuration
+     * @param checkpoints the list of checkpoints
+     * @return a list of checkpoints
+     * @throws Exception if an error occurs while the checkpoints are being
+     *                   loaded from the database.
+     */
+    @Override
+    protected LinkedList<Checkpoint> loadedCheckpoints(RunnableConfig config, LinkedList<Checkpoint> checkpoints)
+            throws Exception {
+        if (!checkpoints.isEmpty()) {
+            return checkpoints;
+        }
+
+        final String threadName = config.threadId().orElse(THREAD_ID_DEFAULT);
+
+        try (Connection connection = dataSource.getConnection();
+                PreparedStatement preparedStatement = connection.prepareStatement(SELECT_CHECKPOINTS)) {
+
+            preparedStatement.setString(1, threadName);
+            try (ResultSet resultSet = preparedStatement.executeQuery()) {
+                while (resultSet.next()) {
+                    String jsonString = resultSet.getString(4);
+                    @SuppressWarnings("unchecked")
+                    Map<String, Object> state = objectMapper.readValue(jsonString, Map.class);
+                    Checkpoint checkpoint = Checkpoint.builder()
+                            .id(resultSet.getString(1))
+                            .nodeId(resultSet.getString(2))
+                            .nextNodeId(resultSet.getString(3))
+                            .state(state)
+                            .build();
+                    checkpoints.add(checkpoint);
+                }
+            }
+        } catch (SQLException sqlException) {
+            throw new Exception("Unable to load checkpoints", sqlException);
+        }
+        return checkpoints;
+    }
+
+    /**
+     * Inserts a checkpoint to the database
+     * 
+     * @param config      the configuration
+     * @param checkpoints the list of checkpoints
+     * @param checkpoint  the checkpoint to insert
+     * @throws Exception if an error occurs while inserting the checkpoint in the
+     *                   database.
+     */
+    @Override
+    protected void insertedCheckpoint(RunnableConfig config, LinkedList<Checkpoint> checkpoints, Checkpoint checkpoint)
+            throws Exception {
+
+        final String threadName = config.threadId().orElse(THREAD_ID_DEFAULT);
+        try (Connection connection = dataSource.getConnection();
+                PreparedStatement upsertStatement = connection.prepareStatement(UPSERT_THREAD);
+                PreparedStatement insertCheckpointStatement = connection.prepareStatement(INSERT_CHECKPOINT)) {
+
+            upsertStatement.setString(1, UUID.randomUUID().toString());
+            upsertStatement.setString(2, threadName);
+            upsertStatement.execute();
+
+            insertCheckpointStatement.setString(1, checkpoint.getId());
+            insertCheckpointStatement.setString(2, checkpoint.getNodeId());
+            insertCheckpointStatement.setString(3, checkpoint.getNextNodeId());
+            insertCheckpointStatement.setString(4, objectMapper.writeValueAsString(checkpoint.getState()));
+            insertCheckpointStatement.setString(5, threadName);
+
+            insertCheckpointStatement.execute();
+        } catch (SQLException sqlException) {
+            throw new RuntimeException("Unable to insert checkpoint", sqlException);
+        }
+
+    }
+
+    /**
+     * Marks the checkpoints as released
+     * 
+     * @param config      the configuration
+     * @param checkpoints the checkpoints
+     * @param releaseTag  the release tag
+     * @throws Exception if an error occurs while marking the checkpoints as
+     *                   released
+     */
+    @Override
+    protected void releasedCheckpoints(RunnableConfig config, LinkedList<Checkpoint> checkpoints, Tag releaseTag)
+            throws Exception {
+        final String threadName = config.threadId().orElse(THREAD_ID_DEFAULT);
+
+        try (Connection connection = dataSource.getConnection();
+                PreparedStatement preparedStatement = connection.prepareStatement(RELEASE_THREAD)) {
+            preparedStatement.setString(1, threadName);
+            preparedStatement.execute();
+        } catch (SQLException sqlException) {
+            throw new Exception("Unable to release checkpoint", sqlException);
+        }
+    }
+
+    /**
+     * If the checkpoint exists, updates the checkpoint, otherwise it inserts it.
+     * 
+     * @param config      the configuration
+     * @param checkpoints the list of checkpoints
+     * @param checkpoint  the checkpoint
+     * @throws Exception if an error occurs while inserting or updating the
+     *                   checkpoint.
+     */
+    @Override
+    protected void updatedCheckpoint(RunnableConfig config, LinkedList<Checkpoint> checkpoints, Checkpoint checkpoint)
+            throws Exception {
+        if (config.checkPointId().isPresent()) {
+            try (Connection connection = dataSource.getConnection();
+                    PreparedStatement preparedStatement = connection.prepareStatement(UPDATE_CHECKPOINT)) {
+                preparedStatement.setString(1, checkpoint.getId());
+                preparedStatement.setString(2, checkpoint.getNodeId());
+                preparedStatement.setString(3, checkpoint.getNextNodeId());
+                preparedStatement.setString(4, objectMapper.writeValueAsString(checkpoint.getState()));
+                preparedStatement.setString(5, config.checkPointId().get());
+                preparedStatement.execute();
+            } catch (SQLException sqlException) {
+                throw new Exception("Unable to update checkpoint", sqlException);
+            }
+        } else {
+            insertedCheckpoint(config, checkpoints, checkpoint);
+        }
+    }
+
+    /**
+     * Initializes the database according the create options.
+     */
+    protected void initTables() {
+        try (Connection connection = dataSource.getConnection();
+                Statement statement = connection.createStatement()) {
+            if (createOption == CreateOption.CREATE_OR_REPLACE) {
+                // Drop tables (indexes are automatically dropped with tables in MySQL)
+                statement.addBatch(DROP_CHECKPOINT_TABLE);
+                statement.addBatch(DROP_THREAD_TABLE);
+                statement.executeBatch();
+            }
+            if (createOption == CreateOption.CREATE_OR_REPLACE ||
+                    createOption == CreateOption.CREATE_IF_NOT_EXISTS) {
+                statement.execute(CREATE_THREAD_TABLE);
+                statement.execute(CREATE_CHECKPOINT_TABLE);
+                
+                // Try to create index, ignore error if it already exists
+                try {
+                    statement.execute(INDEX_THREAD_TABLE);
+                } catch (SQLException e) {
+                    // Ignore "Duplicate key name" error (error code 1061)
+                    if (e.getErrorCode() != 1061) {
+                        throw e;
+                    }
+                }
+            }
+        } catch (SQLException sqlException) {
+            throw new RuntimeException("Unable to create tables", sqlException);
+        }
+    }
+
+    /**
+     * A builder for MysqlSaver.
+     */
+    public static class Builder {
+        private DataSource dataSource;
+        private CreateOption createOption = CreateOption.CREATE_IF_NOT_EXISTS;
+
+        /**
+         * Sets the datasource
+         * 
+         * @param dataSource the datasource
+         * @return this builder
+         */
+        public Builder dataSource(DataSource dataSource) {
+            this.dataSource = dataSource;
+            return this;
+        }
+
+        /**
+         * Sets the create options (default {@link CreateOption#CREATE_IF_NOT_EXISTS}.
+         * 
+         * @param createOption the create options
+         * @return this builder
+         */
+        public Builder createOption(CreateOption createOption) {
+            this.createOption = createOption;
+            return this;
+        }
+
+        /**
+         * Creates a new instance of MysqlSaver
+         * 
+         * @return the new instance of MysqlSaver.
+         */
+        public MysqlSaver build() {
+            return new MysqlSaver(dataSource, createOption);
+        }
+    }
+}

--- a/langgraph4j-mysql-saver/src/test/java/org/bsc/langgraph4j/checkpoint/MysqlSaverTest.java
+++ b/langgraph4j-mysql-saver/src/test/java/org/bsc/langgraph4j/checkpoint/MysqlSaverTest.java
@@ -1,0 +1,196 @@
+package org.bsc.langgraph4j.checkpoint;
+
+import com.mysql.cj.jdbc.MysqlDataSource;
+import org.bsc.langgraph4j.CompileConfig;
+import org.bsc.langgraph4j.RunnableConfig;
+import org.bsc.langgraph4j.StateGraph;
+import org.bsc.langgraph4j.action.NodeAction;
+import org.bsc.langgraph4j.state.AgentState;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.MySQLContainer;
+
+import java.util.Map;
+
+import static org.bsc.langgraph4j.StateGraph.END;
+import static org.bsc.langgraph4j.StateGraph.START;
+import static org.bsc.langgraph4j.action.AsyncNodeAction.node_async;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class MysqlSaverTest {
+
+    protected static final String MYSQL_IMAGE_NAME = "mysql:8.0";
+    protected static MysqlDataSource DATA_SOURCE;
+
+    protected static MySQLContainer<?> mysqlContainer;
+
+    @BeforeAll
+    public static void setup() {
+        try {
+            DATA_SOURCE = new MysqlDataSource();
+            String urlFromEnv = System.getenv("MYSQL_JDBC_URL");
+
+            if (urlFromEnv == null) {
+                @SuppressWarnings("resource")
+                MySQLContainer<?> container = new MySQLContainer<>(MYSQL_IMAGE_NAME)
+                        .withDatabaseName("testdb")
+                        .withUsername("testuser")
+                        .withPassword("testpwd");
+                container.start();
+                mysqlContainer = container;
+
+                initDataSource(
+                        DATA_SOURCE,
+                        mysqlContainer.getJdbcUrl(),
+                        mysqlContainer.getUsername(),
+                        mysqlContainer.getPassword());
+
+            } else {
+                initDataSource(
+                        DATA_SOURCE,
+                        urlFromEnv,
+                        System.getenv("MYSQL_JDBC_USER"),
+                        System.getenv("MYSQL_JDBC_PASSWORD"));
+            }
+
+        } catch (Exception exception) {
+            throw new AssertionError(exception);
+        }
+
+    }
+
+    @AfterAll
+    public static void tearDown() {
+        if (mysqlContainer != null) {
+            mysqlContainer.close();
+        }
+    }
+
+    static void initDataSource(MysqlDataSource dataSource, String url, String username, String password) {
+        dataSource.setURL(url);
+        dataSource.setUser(username);
+        dataSource.setPassword(password);
+    }
+
+    @Test
+    public void testCheckpointWithReleasedThread() throws Exception {
+
+        var saver = MysqlSaver.builder()
+                .dataSource(DATA_SOURCE)
+                .build();
+
+        NodeAction<AgentState> agent_1 = state ->
+             Map.of("agent_1:prop1", "agent_1:test");
+
+
+        var graph = new StateGraph<>(AgentState::new)
+                .addNode("agent_1", node_async(agent_1))
+                .addEdge(START, "agent_1")
+                .addEdge("agent_1", END);
+
+        var compileConfig = CompileConfig.builder()
+                .checkpointSaver(saver)
+                .releaseThread(true)
+                .build();
+
+        var runnableConfig = RunnableConfig.builder()
+                .build();
+        var workflow = graph.compile(compileConfig);
+
+        Map<String, Object> inputs = Map.of("input", "test1");
+
+        var result = workflow.invoke(inputs, runnableConfig);
+
+        assertTrue(result.isPresent());
+
+        var history = workflow.getStateHistory(runnableConfig);
+
+        assertTrue(history.isEmpty());
+
+    }
+
+    @Test
+    public void testCheckpointWithNotReleasedThread() throws Exception {
+        var saver = MysqlSaver.builder()
+                .createOption(CreateOption.CREATE_OR_REPLACE)
+                .dataSource(DATA_SOURCE)
+                .build();
+
+        NodeAction<AgentState> agent_1 = state ->
+            Map.of("agent_1:prop1", "agent_1:test");
+
+
+        var graph = new StateGraph<>(AgentState::new)
+                .addNode("agent_1", node_async(agent_1))
+                .addEdge(START, "agent_1")
+                .addEdge("agent_1", END);
+
+        var compileConfig = CompileConfig.builder()
+                .checkpointSaver(saver)
+                .releaseThread(false)
+                .build();
+
+        var runnableConfig = RunnableConfig.builder().build();
+        var workflow = graph.compile(compileConfig);
+
+        Map<String, Object> inputs = Map.of("input", "test1");
+
+        var result = workflow.invoke(inputs, runnableConfig);
+
+        assertTrue(result.isPresent());
+
+        var history = workflow.getStateHistory(runnableConfig);
+
+        assertFalse(history.isEmpty());
+        assertEquals(2, history.size());
+
+        var lastSnapshot = workflow.lastStateOf(runnableConfig);
+
+        assertTrue(lastSnapshot.isPresent());
+        assertEquals("agent_1", lastSnapshot.get().node());
+        assertEquals(END, lastSnapshot.get().next());
+
+        // UPDATE STATE
+        final var updatedConfig = workflow.updateState(lastSnapshot.get().config(), Map.of("update", "update test"));
+
+        var updatedSnapshot = workflow.stateOf(updatedConfig);
+        assertTrue(updatedSnapshot.isPresent());
+        assertEquals("agent_1", updatedSnapshot.get().node());
+        assertTrue(updatedSnapshot.get().state().value("update").isPresent());
+        assertEquals("update test", updatedSnapshot.get().state().value("update").get());
+        assertEquals(END, lastSnapshot.get().next());
+
+        // test checkpoints reloading from database
+        saver = MysqlSaver.builder()
+                .dataSource(DATA_SOURCE)
+                .build();
+
+        compileConfig = CompileConfig.builder()
+                .checkpointSaver(saver)
+                .releaseThread(false)
+                .build();
+
+        runnableConfig = RunnableConfig.builder().build();
+        workflow = graph.compile(compileConfig);
+
+        history = workflow.getStateHistory(runnableConfig);
+
+        assertFalse(history.isEmpty());
+        assertEquals(2, history.size());
+
+        lastSnapshot = workflow.stateOf(updatedConfig);
+        // lastSnapshot = workflow.lastStateOf( runnableConfig );
+
+        assertTrue(lastSnapshot.isPresent());
+        assertEquals("agent_1", lastSnapshot.get().node());
+        assertEquals(END, lastSnapshot.get().next());
+        assertTrue(lastSnapshot.get().state().value("update").isPresent());
+        assertEquals("update test", lastSnapshot.get().state().value("update").get());
+        assertEquals(END, lastSnapshot.get().next());
+
+        saver.release(runnableConfig);
+
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -236,6 +236,7 @@
     <module>how-tos</module>
     <module>langgraph4j-postgres-saver</module>
     <module>langgraph4j-oracle-saver</module>
+      <module>langgraph4j-mysql-saver</module>
   </modules>
 
   <profiles>


### PR DESCRIPTION
Added new submodule `langgraph4j-mysql-saver`, including the main class `MysqlSaver` and its corresponding test class `MysqlSaverTest`, along with related configuration files and documentation.