### PR TITLE
fix: add tool call check for existing lastResponse

### DIFF
--- a/spring-ai/spring-ai-core/src/main/java/org/bsc/langgraph4j/spring/ai/generators/StreamingChatGenerator.java
+++ b/spring-ai/spring-ai-core/src/main/java/org/bsc/langgraph4j/spring/ai/generators/StreamingChatGenerator.java
@@ -1,5 +1,12 @@
 package org.bsc.langgraph4j.spring.ai.generators;
 
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import java.util.function.Function;
 import org.bsc.async.AsyncGenerator;
 import org.bsc.async.FlowGenerator;
 import org.bsc.langgraph4j.NodeOutput;
@@ -10,14 +17,6 @@ import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.model.Generation;
 import reactor.core.publisher.Flux;
-
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Consumer;
-import java.util.function.Function;
-
-import static java.util.Objects.requireNonNull;
 
 public interface StreamingChatGenerator {
 
@@ -78,6 +77,10 @@ public interface StreamingChatGenerator {
                     }
 
                     final var currentMessage = response.getResult().getOutput();
+
+                    if (lastResponse.hasToolCalls()) {
+                      return lastResponse;
+                    }
 
                     if( currentMessage.hasToolCalls() ) {
                         return response;


### PR DESCRIPTION
When using streaming in CallModelAction, I found that the chatResponse containing toolcall returned by the agent was being lost. I discovered that in the StreamingChatGenerator.build processing logic, when a cached chatResponse containing toolcall already exists in the result, and the next chatResponse is of plain text type, the original logic merges the cached toolcall as a text message, resulting in the loss of the toolcall chatResponse. In my fix, I added validation for the cache - when I detect that the cache contains a toolcall, I stop the processing. This may also introduce some issues, such as with concurrent tool calls. Developers may want to consider redesigning the logic in this area.