### PR TITLE
refactor(spring-ai): bump spring-ai from 1.0.3 to 1.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
     <langchain4j.version>1.7.1</langchain4j.version>
     <!--langchain4j.rc>1.1.0-rc1</langchain4j.rc -->
     <langchain4j.beta>1.7.1-beta14</langchain4j.beta>
-    <spring-ai.version>1.0.3</spring-ai.version>
+    <spring-ai.version>1.1.0</spring-ai.version>
     <flatten-maven-plugin.version>1.5.0</flatten-maven-plugin.version>
   </properties>
 

--- a/spring-ai/spring-ai-agent/src/main/java/org/bsc/langgraph4j/spring/ai/agentexecutor/AgentExecutorEx.java
+++ b/spring-ai/spring-ai-agent/src/main/java/org/bsc/langgraph4j/spring/ai/agentexecutor/AgentExecutorEx.java
@@ -224,7 +224,7 @@ public interface AgentExecutorEx {
                                 })
                                 .toList();
 
-                var toolResponseMessages = new ToolResponseMessage( toolResponses );
+                var toolResponseMessages = ToolResponseMessage.builder().responses(toolResponses).build();
 
                 result.complete( new Command( resumeState,
                         Map.of( "messages",toolResponseMessages,

--- a/spring-ai/spring-ai-agent/src/test/java/org/bsc/langgraph4j/spring/ai/agentexecutor/ChatModelConfiguration.java
+++ b/spring-ai/spring-ai-agent/src/test/java/org/bsc/langgraph4j/spring/ai/agentexecutor/ChatModelConfiguration.java
@@ -5,7 +5,7 @@ import com.google.cloud.vertexai.VertexAI;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.ollama.OllamaChatModel;
 import org.springframework.ai.ollama.api.OllamaApi;
-import org.springframework.ai.ollama.api.OllamaOptions;
+import org.springframework.ai.ollama.api.OllamaChatOptions;
 import org.springframework.ai.openai.OpenAiChatModel;
 import org.springframework.ai.openai.OpenAiChatOptions;
 import org.springframework.ai.openai.api.OpenAiApi;
@@ -23,7 +23,7 @@ public class ChatModelConfiguration {
     public ChatModel ollamaModel() {
         return OllamaChatModel.builder()
                 .ollamaApi(OllamaApi.builder().baseUrl("http://localhost:11434").build())
-                .defaultOptions(OllamaOptions.builder()
+                .defaultOptions(OllamaChatOptions.builder()
                         //.model("qwen2.5:7b")
                         .model("gpt-oss:20b")
                         .temperature(0.1)

--- a/spring-ai/spring-ai-core/src/main/java/org/bsc/langgraph4j/spring/ai/generators/StreamingChatGenerator.java
+++ b/spring-ai/spring-ai-core/src/main/java/org/bsc/langgraph4j/spring/ai/generators/StreamingChatGenerator.java
@@ -94,14 +94,13 @@ public interface StreamingChatGenerator {
 
                     final var currentMessageText = currentMessage.getText();
 
-                    var newMessage =  new AssistantMessage(
-                            currentMessageText != null ?
-                                    lastMessageText.concat( currentMessageText ) :
-                                    lastMessageText,
-                            currentMessage.getMetadata(),
-                            toolCalls,
-                            currentMessage.getMedia()
-                    );
+                    var newMessage =  AssistantMessage.builder()
+                        .content(currentMessageText != null ?
+                            lastMessageText.concat( currentMessageText ) :
+                            lastMessageText)
+                        .toolCalls(toolCalls)
+                        .media(currentMessage.getMedia())
+                        .build();
 
                     var newGeneration = new Generation(newMessage, response.getResult().getMetadata());
                     return new ChatResponse( List.of(newGeneration), response.getMetadata());

--- a/spring-ai/spring-ai-core/src/main/java/org/bsc/langgraph4j/spring/ai/serializer/jackson/AssistantMessageHandler.java
+++ b/spring-ai/spring-ai-core/src/main/java/org/bsc/langgraph4j/spring/ai/serializer/jackson/AssistantMessageHandler.java
@@ -81,7 +81,10 @@ public interface AssistantMessageHandler {
             var requestsNode = node.findValue(Field.TOOL_CALLS.name);
 
             if( requestsNode.isNull() || requestsNode.isEmpty() ) {
-                return new AssistantMessage( text, metadata );
+                return AssistantMessage.builder()
+                    .content(text)
+                    .properties(metadata)
+                    .build();
             }
 
             var requests = new LinkedList<AssistantMessage.ToolCall>();
@@ -93,7 +96,11 @@ public interface AssistantMessageHandler {
                 requests.add(request);
             }
 
-            return new AssistantMessage( text, metadata, requests );
+            return AssistantMessage.builder()
+                .content(text)
+                .properties(metadata)
+                .toolCalls(requests)
+                .build();
         }
 
     }

--- a/spring-ai/spring-ai-core/src/main/java/org/bsc/langgraph4j/spring/ai/serializer/jackson/ToolResponseMessageHandler.java
+++ b/spring-ai/spring-ai-core/src/main/java/org/bsc/langgraph4j/spring/ai/serializer/jackson/ToolResponseMessageHandler.java
@@ -76,7 +76,7 @@ public interface ToolResponseMessageHandler {
             var metadata = deserializeMetadata( mapper, node );
 
             if( responsesNode.isNull() || responsesNode.isEmpty() ) {
-                return new ToolResponseMessage( List.of(), metadata );
+                return ToolResponseMessage.builder().metadata(metadata).build();
             }
 
             var responses = new ArrayList<ToolResponseMessage.ToolResponse>( responsesNode.size() );
@@ -84,7 +84,7 @@ public interface ToolResponseMessageHandler {
                 responses.add( mapper.treeToValue( responseNode, ToolResponseMessage.ToolResponse.class ) );
             }
 
-            return new ToolResponseMessage( responses, metadata );
+            return ToolResponseMessage.builder().responses(responses).metadata(metadata).build();
         }
     }
 }

--- a/spring-ai/spring-ai-core/src/main/java/org/bsc/langgraph4j/spring/ai/serializer/std/AssistantMessageSerializer.java
+++ b/spring-ai/spring-ai-core/src/main/java/org/bsc/langgraph4j/spring/ai/serializer/std/AssistantMessageSerializer.java
@@ -27,6 +27,10 @@ class AssistantMessageSerializer implements NullableObjectSerializer<AssistantMe
         var text = readNullableUTF(in).orElse(null);
         var metadata = (Map<String, Object>)in.readObject();
         var toolCalls = (List<AssistantMessage.ToolCall>)readNullableObject(in).orElseGet(List::of);
-        return new AssistantMessage( text, metadata, toolCalls);
+        return AssistantMessage.builder()
+            .content(text)
+            .properties(metadata)
+            .toolCalls(toolCalls)
+            .build();
     }
 }

--- a/spring-ai/spring-ai-core/src/main/java/org/bsc/langgraph4j/spring/ai/serializer/std/ToolResponseMessageSerializer.java
+++ b/spring-ai/spring-ai-core/src/main/java/org/bsc/langgraph4j/spring/ai/serializer/std/ToolResponseMessageSerializer.java
@@ -22,6 +22,6 @@ class ToolResponseMessageSerializer implements Serializer<ToolResponseMessage> {
     public ToolResponseMessage read(ObjectInput in) throws IOException, ClassNotFoundException {
         var response = (List<ToolResponseMessage.ToolResponse>)in.readObject();
         var metadata = (Map<String,Object>)in.readObject();
-        return new ToolResponseMessage( response, metadata );
+        return ToolResponseMessage.builder().responses(response).metadata(metadata).build();
     }
 }

--- a/spring-ai/spring-ai-core/src/main/java/org/bsc/langgraph4j/spring/ai/tool/SpringAIToolService.java
+++ b/spring-ai/spring-ai-core/src/main/java/org/bsc/langgraph4j/spring/ai/tool/SpringAIToolService.java
@@ -99,7 +99,7 @@ public class SpringAIToolService {
 
         }
 
-        update = mergeMap( update, Map.of(propertyNameToUpdate, new ToolResponseMessage( toolResponses )) );
+        update = mergeMap( update, Map.of(propertyNameToUpdate, ToolResponseMessage.builder().responses(toolResponses).build()) );
 
         return completedFuture( new Command( gotoNode, update  ) );
     }

--- a/spring-ai/spring-ai-core/src/test/java/org/bsc/langgraph4j/spring/ai/StreamingTestITest.java
+++ b/spring-ai/spring-ai-core/src/test/java/org/bsc/langgraph4j/spring/ai/StreamingTestITest.java
@@ -19,7 +19,7 @@ import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.model.tool.ToolCallingChatOptions;
 import org.springframework.ai.ollama.OllamaChatModel;
 import org.springframework.ai.ollama.api.OllamaApi;
-import org.springframework.ai.ollama.api.OllamaOptions;
+import org.springframework.ai.ollama.api.OllamaChatOptions;
 import org.springframework.ai.openai.OpenAiChatModel;
 import org.springframework.ai.openai.OpenAiChatOptions;
 import org.springframework.ai.openai.api.OpenAiApi;
@@ -73,7 +73,7 @@ public class StreamingTestITest {
         OLLAMA_QWEN3_14B(
                 OllamaChatModel.builder()
                         .ollamaApi( OllamaApi.builder().baseUrl("http://localhost:11434").build() )
-                        .defaultOptions(OllamaOptions.builder()
+                        .defaultOptions(OllamaChatOptions.builder()
                                 .model("qwen3.1:14b")
                                 .temperature(0.1)
                                 .build())
@@ -81,7 +81,7 @@ public class StreamingTestITest {
         OLLAMA_QWEN2_5_7B(
                 OllamaChatModel.builder()
                         .ollamaApi( OllamaApi.builder().baseUrl("http://localhost:11434").build() )
-                        .defaultOptions(OllamaOptions.builder()
+                        .defaultOptions(OllamaChatOptions.builder()
                                 .model("qwen2.5:7b")
                                 .temperature(0.1)
                                 .build())

--- a/spring-ai/spring-ai-core/src/test/java/org/bsc/langgraph4j/spring/ai/serializer/jackson/AssistantMessageSerializeTest.java
+++ b/spring-ai/spring-ai-core/src/test/java/org/bsc/langgraph4j/spring/ai/serializer/jackson/AssistantMessageSerializeTest.java
@@ -41,7 +41,10 @@ public class AssistantMessageSerializeTest {
 
         Map<String,Object> metadata = Map.of( "key1", "value1", "key2", 100 );
 
-        var message = new AssistantMessage( "Hello world", metadata);
+        var message = AssistantMessage.builder()
+            .content("Hello world")
+            .properties(metadata)
+            .build();
 
         var state = serializer.cloneObject( Map.of( "assistant1", message) );
 
@@ -76,7 +79,11 @@ public class AssistantMessageSerializeTest {
                 new AssistantMessage.ToolCall( "t2", "function", "test2", "{ param: 'value'}" )
         );
 
-        var message = new AssistantMessage( "Hello world", metadata, toolCalls);
+        var message = AssistantMessage.builder()
+            .content("Hello world")
+            .properties(metadata)
+            .toolCalls(toolCalls)
+            .build();
 
         var state = serializer.cloneObject( Map.of( "assistant1", message) );
 

--- a/spring-ai/spring-ai-core/src/test/java/org/bsc/langgraph4j/spring/ai/serializer/jackson/ToolResponseMessageTest.java
+++ b/spring-ai/spring-ai-core/src/test/java/org/bsc/langgraph4j/spring/ai/serializer/jackson/ToolResponseMessageTest.java
@@ -26,7 +26,7 @@ public class ToolResponseMessageTest {
         List<ToolResponseMessage.ToolResponse> toolResponses = List.of(
         );
 
-        var message = new ToolResponseMessage( toolResponses, metadata );
+        var message = ToolResponseMessage.builder().responses(toolResponses).metadata(metadata).build();
 
         var state = serializer.cloneObject( Map.of( "tool_response", message) );
 
@@ -59,7 +59,7 @@ public class ToolResponseMessageTest {
                 new ToolResponseMessage.ToolResponse( "t2", "test2", "{ result: 'OK'}" )
         );
 
-        var message = new ToolResponseMessage( toolResponses, metadata );
+        var message = ToolResponseMessage.builder().responses(toolResponses).metadata(metadata).build();
 
         var state = serializer.cloneObject( Map.of( "tool_response", message) );
 


### PR DESCRIPTION
Spring AI has released version 1.1.0. This PR upgrades Spring AI from 1.0.3 to 1.1.0, with all necessary code compatibility adjustments made. Post-upgrade testing has passed successfully; could you please merge and release it as soon as possible?