### PR TITLE
feat: add support for 'thinking' field in AiMessage 

### DIFF
--- a/langchain4j/langchain4j-core/src/main/java/org/bsc/langgraph4j/langchain4j/serializer/jackson/AiMessageHandler.java
+++ b/langchain4j/langchain4j-core/src/main/java/org/bsc/langgraph4j/langchain4j/serializer/jackson/AiMessageHandler.java
@@ -31,10 +31,17 @@ public interface AiMessageHandler {
             ObjectNode node = mapper.readTree(jsonParser);
 
             var text = node.findValue( "text" ).asText();
+            var thinking =  node.findValue("thinking");
+
+            AiMessage.Builder builder = AiMessage.builder().text(text);
+            if (thinking != null && !thinking.isNull()) {
+                builder.thinking(thinking.asText());
+            }
+
             var requestsNode = node.findValue("toolExecutionRequests");
 
             if( requestsNode.isNull() || requestsNode.isEmpty() ) {
-                return AiMessage.from( text );
+                return builder.build();
             }
 
             var requests = new LinkedList<ToolExecutionRequest>();
@@ -46,8 +53,7 @@ public interface AiMessageHandler {
                 requests.add(request);
             }
 
-            return AiMessage.builder()
-                    .text( text )
+            return builder
                     .toolExecutionRequests( requests)
                     .build();
         }
@@ -66,6 +72,7 @@ public interface AiMessageHandler {
             gen.writeStringField("@type", msg.type().name());
             gen.writeStringField("text", msg.text());
             gen.writeObjectField("toolExecutionRequests", msg.toolExecutionRequests());
+            gen.writeStringField("thinking", msg.thinking());
             gen.writeEndObject();
         }
     }


### PR DESCRIPTION
This pull request updates the Jackson serializer and deserializer for the `AiMessage` class to support a new `thinking` field. The changes ensure that this field is correctly handled during both serialization and deserialization, improving extensibility and data integrity for AI message objects.

**Enhancements to `AiMessage` serialization and deserialization:**

* Updated the deserialization method to extract the `thinking` field from JSON and set it on the `AiMessage` builder if present.
* Modified the serialization method to write the `thinking` field to JSON output.
* Refactored deserialization logic to consistently use the builder pattern for constructing `AiMessage` objects, ensuring that all fields (including `thinking` and `toolExecutionRequests`) are properly set.