### PR TITLE
fix: set test scope for langgraph4j-studio-jetty dependency , in case…

### DIFF
--- a/langgraph4j-postgres-saver/pom.xml
+++ b/langgraph4j-postgres-saver/pom.xml
@@ -62,6 +62,7 @@
             <groupId>${project.parent.groupId}</groupId>
             <artifactId>langgraph4j-studio-jetty</artifactId>
             <version>${project.parent.version}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
HI @bsorrentino 

fix: set test scope for langgraph4j-studio-jetty dependency , in case of dependency conflict eg: "slf4j-jdk14"  with application level maybe "logback-classic"