### PR TITLE
fix memory saver

### DIFF
--- a/langgraph4j-core/src/main/java/org/bsc/langgraph4j/checkpoint/MemorySaver.java
+++ b/langgraph4j-core/src/main/java/org/bsc/langgraph4j/checkpoint/MemorySaver.java
@@ -51,7 +51,7 @@ public class MemorySaver implements BaseCheckpointSaver {
     @Override
     public final Collection<Checkpoint> list( RunnableConfig config ) {
         try {
-            return loadOrInitCheckpoints( config, Collections::unmodifiableCollection);
+            return loadOrInitCheckpoints( config, List::copyOf);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
MemorySaver.list() returns Collections.unmodifiableCollection(checkpoints), which is just a view over the original LinkedList. After loadOrInitCheckpoints releases the lock, a caller could be iterating that view while another thread (holding the lock) mutates the underlying list — that would cause a ConcurrentModificationException. A defensive copy (e.g., List.copyOf(checkpoints)) in list() would be safer than an unmodifiable view. 